### PR TITLE
Fix arithmetic on nill in rpm

### DIFF
--- a/rpm.lua
+++ b/rpm.lua
@@ -86,14 +86,16 @@ local function parseManifest(manifest)
     while true do
         local pos = string.find(manifest,"\n")
         local line = manifest
-        if pos then
-            line = string.sub(manifest,1,pos-1)
-            manifest = string.sub(manifest,pos+1,#manifest)
-        end
-        line = string.gsub(line," ","")
-        local pos2 = string.find(line,">")
-        files[#files+1] = {string.sub(line,1,pos2-1),string.sub(line,pos2+1,#line)}
-        if not pos then break end
+        if #line > 0 then
+            if pos then
+                line = string.sub(manifest,1,pos-1)
+                manifest = string.sub(manifest,pos+1,#manifest)
+            end
+            line = string.gsub(line," ","")
+            local pos2 = string.find(line,">")
+            files[#files+1] = {string.sub(line,1,pos2-1),string.sub(line,pos2+1,#line)}
+            if not pos then break end
+        else break end
     end
     return files
 end


### PR DESCRIPTION
When I tried to install `ccbank/backend` with rpm I got this error:

```
/rpm.lua:95: attempt to perform arithmetic  on local 'pos2' (a nill value)
````

After inserting a `print(line)` before line 95 I noticed the line before the error was blank. So I added an extra if statement to check if the line's length is greater than 0. This is has now fixed the error.

**Screenshot of debugging**

![image](https://github.com/Reactified/rpm/assets/41990982/aa3143b0-5131-4332-858d-7f5549e41158)
